### PR TITLE
Early audit log reason support!

### DIFF
--- a/Sources/Sword/Rest/Request.swift
+++ b/Sources/Sword/Rest/Request.swift
@@ -25,7 +25,7 @@ extension Sword {
    - parameter method: Type of HTTP Method
    - parameter rateLimited: Whether or not the HTTP request needs to be rate limited
   */
-    func request(_ endpoint: Endpoint, body: [String: Any]? = nil, reason: String? = nil, file: String? = nil, authorization: Bool = true, rateLimited: Bool = true, then completion: @escaping (Any?, RequestError?) -> ()) {
+  func request(_ endpoint: Endpoint, body: [String: Any]? = nil, reason: String? = nil, file: String? = nil, authorization: Bool = true, rateLimited: Bool = true, then completion: @escaping (Any?, RequestError?) -> ()) {
     let sema = DispatchSemaphore(value: 0) //Provide a way to urlsession from command line
 
     let endpointInfo = endpoint.httpInfo

--- a/Sources/Sword/Rest/Request.swift
+++ b/Sources/Sword/Rest/Request.swift
@@ -20,11 +20,12 @@ extension Sword {
    - parameter url: URL to request
    - parameter body: Optional Data to send to server
    - parameter file: Optional for when files
+   - parameter reason: Optional for when user wants to specify audit-log reason
    - parameter authorization: Whether or not the Authorization header is required by Discord
    - parameter method: Type of HTTP Method
    - parameter rateLimited: Whether or not the HTTP request needs to be rate limited
   */
-  func request(_ endpoint: Endpoint, body: [String: Any]? = nil, file: String? = nil, authorization: Bool = true, rateLimited: Bool = true, then completion: @escaping (Any?, RequestError?) -> ()) {
+    func request(_ endpoint: Endpoint, body: [String: Any]? = nil, reason: String? = nil, file: String? = nil, authorization: Bool = true, rateLimited: Bool = true, then completion: @escaping (Any?, RequestError?) -> ()) {
     let sema = DispatchSemaphore(value: 0) //Provide a way to urlsession from command line
 
     let endpointInfo = endpoint.httpInfo
@@ -38,6 +39,10 @@ extension Sword {
 
     if authorization {
       request.addValue("Bot \(token)", forHTTPHeaderField: "Authorization")
+    }
+    
+    if reason != nil {
+      request.addValue(reason!, forHTTPHeaderField: "X-Audit-Log-Reason")
     }
 
     request.addValue("DiscordBot (https://github.com/Azoy/Sword, 0.5.0)", forHTTPHeaderField: "User-Agent")

--- a/Sources/Sword/Sword.swift
+++ b/Sources/Sword/Sword.swift
@@ -190,9 +190,10 @@ open class Sword: Eventable {
    - parameter userId: Member to ban
    - parameter guildId: Guild to ban member in
    - parameter options: Deletes messages from this user by amount of days
+   - parameter reason: Optional -- reason for ban (attached to audit log)
   */
-  public func ban(_ userId: String, in guildId: String, with options: [String: Int] = [:], then completion: @escaping (RequestError?) -> () = {_ in}) {
-    self.request(.createGuildBan(guildId, userId), body: options) { data, error in
+    public func ban(_ userId: String, in guildId: String, with options: [String: Int] = [:], with reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
+      self.request(.createGuildBan(guildId, userId), body: options, reason: reason) { data, error in
       completion(error)
     }
   }
@@ -1405,9 +1406,10 @@ open class Sword: Eventable {
 
    - parameter userId: Member to remove from server
    - parameter guildId: Guild to remove them from
+   - parameter reason: Optional -- reason to remove the member from guild (attached to audit log)
   */
-  public func removeMember(_ userId: String, from guildId: String, then completion: @escaping (RequestError?) -> () = {_ in}) {
-    self.request(.removeGuildMember(guildId, userId)) { data, error in
+  public func removeMember(_ userId: String, from guildId: String, with reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
+    self.request(.removeGuildMember(guildId, userId), reason: reason) { data, error in
       completion(error)
     }
   }

--- a/Sources/Sword/Sword.swift
+++ b/Sources/Sword/Sword.swift
@@ -192,7 +192,7 @@ open class Sword: Eventable {
    - parameter options: Deletes messages from this user by amount of days
    - parameter reason: Optional -- reason for ban (attached to audit log)
   */
-    public func ban(_ userId: String, in guildId: String, with options: [String: Int] = [:], with reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
+    public func ban(_ userId: String, in guildId: String, with options: [String: Int] = [:], for reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
       self.request(.createGuildBan(guildId, userId), body: options, reason: reason) { data, error in
       completion(error)
     }
@@ -1408,7 +1408,7 @@ open class Sword: Eventable {
    - parameter guildId: Guild to remove them from
    - parameter reason: Optional -- reason to remove the member from guild (attached to audit log)
   */
-  public func removeMember(_ userId: String, from guildId: String, with reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
+  public func removeMember(_ userId: String, from guildId: String, for reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
     self.request(.removeGuildMember(guildId, userId), reason: reason) { data, error in
       completion(error)
     }

--- a/Sources/Sword/Sword.swift
+++ b/Sources/Sword/Sword.swift
@@ -192,7 +192,7 @@ open class Sword: Eventable {
    - parameter options: Deletes messages from this user by amount of days
    - parameter reason: Optional -- reason for ban (attached to audit log)
   */
-    public func ban(_ userId: String, in guildId: String, with options: [String: Int] = [:], for reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
+  public func ban(_ userId: String, in guildId: String, with options: [String: Int] = [:], for reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
       self.request(.createGuildBan(guildId, userId), body: options, reason: reason) { data, error in
       completion(error)
     }

--- a/Sources/Sword/Sword.swift
+++ b/Sources/Sword/Sword.swift
@@ -189,11 +189,11 @@ open class Sword: Eventable {
 
    - parameter userId: Member to ban
    - parameter guildId: Guild to ban member in
-   - parameter options: Deletes messages from this user by amount of days
    - parameter reason: Optional -- reason for ban (attached to audit log)
+   - parameter options: Deletes messages from this user by amount of days
   */
-  public func ban(_ userId: String, in guildId: String, with options: [String: Int] = [:], for reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
-      self.request(.createGuildBan(guildId, userId), body: options, reason: reason) { data, error in
+  public func ban(_ userId: String, in guildId: String, for reason: String? = nil, with options: [String: Int] = [:], then completion: @escaping (RequestError?) -> () = {_ in}) {
+    self.request(.createGuildBan(guildId, userId), body: options, reason: reason) { data, error in
       completion(error)
     }
   }

--- a/Sources/Sword/Types/Guild.swift
+++ b/Sources/Sword/Types/Guild.swift
@@ -189,10 +189,11 @@ public class Guild {
    - **delete-message-days**: Number of days to delete messages for (0-7)
 
    - parameter userId: Member to ban
+   - parameter reason: Optional -- reason to ban the member (attached to audit log)
    - parameter options: Deletes messages from this user by amount of days
   */
-  public func ban(_ member: String, with options: [String: Int] = [:], then completion: @escaping (RequestError?) -> () = {_ in}) {
-    self.sword?.ban(member, in: self.id, with: options, then: completion)
+  public func ban(_ member: String, for reason: String? = nil, with options: [String: Int] = [:], then completion: @escaping (RequestError?) -> () = {_ in}) {
+    self.sword?.ban(member, in: self.id, for: reason, with: options, then: completion)
   }
 
   /**
@@ -443,8 +444,8 @@ public class Guild {
 
    - parameter userId: Member to remove from server
   */
-  public func removeMember(_ userId: String, then completion: @escaping (RequestError?) -> () = {_ in}) {
-    self.sword?.removeMember(userId, from: self.id, then: completion)
+  public func removeMember(_ userId: String, for reason: String? = nil, then completion: @escaping (RequestError?) -> () = {_ in}) {
+    self.sword?.removeMember(userId, from: self.id, for: reason, then: completion)
   }
 
   /**


### PR DESCRIPTION
I was considering making this part of the kick & ban enum, but I decided against it since any admin action can have a reason attached.

This will allow users to specify who requested what on things such as channel create, which, if requested can be easily added.

Currently, I only added the optional `reason` parameter to `ban`, and `removeMember`, however, it is extremely easy to add support for other types of auditable action.