### PR TITLE
Switch event system to use tuples instead of varargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bot.on(.ready) { [unowned bot] _ in
 }
 
 bot.on(.messageCreate) { data in
-  let msg = data[0] as! Message
+  let msg = data as! Message
   if msg.content == "!ping" {
     msg.reply(with: "Pong!")
   }

--- a/Sources/Sword/Gateway/EventHandler.swift
+++ b/Sources/Sword/Gateway/EventHandler.swift
@@ -87,11 +87,11 @@ extension Shard {
 
       /// GUILD_BAN_ADD
       case .guildBanAdd:
-        self.sword.emit(.guildBanAdd, with: self.sword.guilds[data["guild_id"] as! String]!, User(self.sword, data["user"] as! [String: Any]))
+        self.sword.emit(.guildBanAdd, with: (self.sword.guilds[data["guild_id"] as! String]!, User(self.sword, data["user"] as! [String: Any])))
 
       /// GUILD_BAN_REMOVE
       case .guildBanRemove:
-        self.sword.emit(.guildBanRemove, with: self.sword.guilds[data["guild_id"] as! String]!, User(self.sword, data["user"] as! [String: Any]))
+        self.sword.emit(.guildBanRemove, with: (self.sword.guilds[data["guild_id"] as! String]!, User(self.sword, data["user"] as! [String: Any])))
 
       /// GUILD_CREATE
       case .guildCreate:
@@ -131,7 +131,7 @@ extension Shard {
         for emoji in emojis {
           emitEmojis.append(Emoji(emoji))
         }
-        self.sword.emit(.guildEmojisUpdate, with: self.sword.guilds[data["guild_id"] as! String]!, emitEmojis)
+        self.sword.emit(.guildEmojisUpdate, with: (self.sword.guilds[data["guild_id"] as! String]!, emitEmojis))
 
       /// GUILD_INTEGRATIONS_UPDATE
       case .guildIntegrationsUpdate:
@@ -142,14 +142,14 @@ extension Shard {
         let guild = self.sword.guilds[data["guild_id"] as! String]!
         let member = Member(self.sword, guild, data)
         guild.members[member.user.id] = member
-        self.sword.emit(.guildMemberAdd, with: guild, member)
+        self.sword.emit(.guildMemberAdd, with: (guild, member))
 
       /// GUILD_MEMBER_REMOVE
       case .guildMemberRemove:
         let guild = self.sword.guilds[data["guild_id"] as! String]!
         let user = User(self.sword, data["user"] as! [String: Any])
         guild.members.removeValue(forKey: user.id)
-        self.sword.emit(.guildMemberRemove, with: guild, user)
+        self.sword.emit(.guildMemberRemove, with: (guild, user))
 
       /// GUILD_MEMBERS_CHUNK
       case .guildMembersChunk:
@@ -172,21 +172,21 @@ extension Shard {
         let guild = self.sword.guilds[data["guild_id"] as! String]!
         let role = Role(data["role"] as! [String: Any])
         guild.roles[role.id] = role
-        self.sword.emit(.guildRoleCreate, with: guild, role)
+        self.sword.emit(.guildRoleCreate, with: (guild, role))
 
       /// GUILD_ROLE_DELETE
       case .guildRoleDelete:
         let guild = self.sword.guilds[data["guild_id"] as! String]!
         let role = guild.roles[data["role_id"] as! String]!
         guild.roles.removeValue(forKey: role.id)
-        self.sword.emit(.guildRoleDelete, with: guild, role)
+        self.sword.emit(.guildRoleDelete, with: (guild, role))
 
       /// GUILD_ROLE_UPDATE
       case .guildRoleUpdate:
         let guild = self.sword.guilds[data["guild_id"] as! String]!
         let role = Role(data["role"] as! [String: Any])
         guild.roles[role.id] = role
-        self.sword.emit(.guildRoleUpdate, with: guild, role)
+        self.sword.emit(.guildRoleUpdate, with: (guild, role))
 
       /// GUILD_UPDATE
       case .guildUpdate:
@@ -211,16 +211,16 @@ extension Shard {
         let guild = self.sword.getGuild(for: channelId)
         if guild != nil {
           guard let msg = guild!.channels[channelId]!.messages[data["id"] as! String] else {
-            self.sword.emit(.messageDelete, with: data["id"] as! String, guild!.channels[channelId]!)
+            self.sword.emit(.messageDelete, with: (data["id"] as! String, guild!.channels[channelId]!))
             return
           }
-          self.sword.emit(.messageDelete, with: msg, guild!.channels[channelId]!)
+          self.sword.emit(.messageDelete, with: (msg, guild!.channels[channelId]!))
         }else {
           guard let msg = self.sword.getDM(for: channelId)!.messages[data["id"] as! String] else {
-            self.sword.emit(.messageDelete, with: data["id"] as! String, self.sword.getDM(for: channelId)!)
+            self.sword.emit(.messageDelete, with: (data["id"] as! String, self.sword.getDM(for: channelId)!))
             return
           }
-          self.sword.emit(.messageDelete, with: msg, self.sword.getDM(for: channelId)!)
+          self.sword.emit(.messageDelete, with: (msg, self.sword.getDM(for: channelId)!))
         }
 
       /// MESSAGE_BULK_DELETE
@@ -237,7 +237,7 @@ extension Shard {
               messages.append(messageId)
             }
           }
-          self.sword.emit(.messageDelete, with: messages, guild!.channels[channelId]!)
+          self.sword.emit(.messageDelete, with: (messages, guild!.channels[channelId]!))
         }else {
           let dm = self.sword.getDM(for: channelId)!
           for messageId in messageIds {
@@ -247,7 +247,7 @@ extension Shard {
               messages.append(messageId)
             }
           }
-          self.sword.emit(.messageDeleteBulk, with: messages, dm)
+          self.sword.emit(.messageDeleteBulk, with: (messages, dm))
         }
 
       /// MESSAGE_UPDATE
@@ -261,7 +261,7 @@ extension Shard {
         if self.sword.guilds[data["guild_id"] as! String]!.members[userId] != nil {
           self.sword.guilds[data["guild_id"] as! String]!.members[userId]!.presence = presence
         }
-        self.sword.emit(.presenceUpdate, with: userId, presence)
+        self.sword.emit(.presenceUpdate, with: (userId, presence))
 
       /// READY
       case .ready:
@@ -301,9 +301,9 @@ extension Shard {
         let guild = self.sword.getGuild(for: channelId)
 
         if guild != nil {
-          self.sword.emit(.typingStart, with: guild!.channels[channelId]!, data["user_id"] as! String, timestamp)
+          self.sword.emit(.typingStart, with: (guild!.channels[channelId]!, data["user_id"] as! String, timestamp))
         }else {
-          self.sword.emit(.typingStart, with: self.sword.getDM(for: channelId)!, data["user_id"] as! String, timestamp)
+          self.sword.emit(.typingStart, with: (self.sword.getDM(for: channelId)!, data["user_id"] as! String, timestamp))
         }
 
       /// USER_UPDATE
@@ -323,7 +323,7 @@ extension Shard {
           self.sword.guilds[guildId]!.voiceStates[userId] = voiceState
           self.sword.guilds[guildId]!.members[userId]?.voiceState = voiceState
 
-          self.sword.emit(.voiceChannelJoin, with: userId, voiceState)
+          self.sword.emit(.voiceChannelJoin, with: (userId, voiceState))
         }else {
           self.sword.guilds[guildId]!.voiceStates.removeValue(forKey: userId)
           self.sword.guilds[guildId]!.members[userId]?.voiceState = nil

--- a/Sources/Sword/Gateway/Eventable.swift
+++ b/Sources/Sword/Gateway/Eventable.swift
@@ -10,18 +10,18 @@
 public protocol Eventable: class {
 
   /// Event Listeners
-  var listeners: [Event: [([Any]) -> ()]] { get set }
+  var listeners: [Event: [(Any) -> ()]] { get set }
 
   /**
    - parameter event: Event to listen for
    */
-  func on(_ event: Event, do function: @escaping ([Any]) -> ())
+  func on(_ event: Event, do function: @escaping (Any) -> ())
 
   /**
    - parameter event: Event to emit
    - parameter data: Array of stuff to emit listener with
    */
-  func emit(_ event: Event, with data: Any...)
+  func emit(_ event: Event, with data: Any)
 
 }
 
@@ -32,7 +32,7 @@ extension Eventable {
 
    - parameter event: Event to listen for
    */
-  public func on(_ event: Event, do function: @escaping ([Any]) -> ()) {
+  public func on(_ event: Event, do function: @escaping (Any) -> ()) {
     guard self.listeners[event] != nil else {
       self.listeners[event] = [function]
       return
@@ -47,7 +47,7 @@ extension Eventable {
    - parameter event: Event to emit
    - parameter data: Array of stuff to emit listener with
    */
-  public func emit(_ event: Event, with data: Any...) {
+  public func emit(_ event: Event, with data: Any = ()) {
     guard let functions = self.listeners[event] else { return }
 
     for function in functions {

--- a/Sources/Sword/Shield/Shield.swift
+++ b/Sources/Sword/Shield/Shield.swift
@@ -32,7 +32,7 @@ open class Shield: Sword {
     super.init(token: token, with: swordOptions)
 
     self.on(.ready) { [unowned self] data in
-      let bot = data[0] as! User
+      let bot = data as! User
 
       if self.shieldOptions.prefixes.contains("@bot") {
         self.shieldOptions.prefixes.remove(at: self.shieldOptions.prefixes.index(of: "@bot")!)
@@ -50,8 +50,8 @@ open class Shield: Sword {
    Handles MESSAGE_CREATE
    - parameter data: The [Any] that needs to be casted to Message to handle the message
   */
-  func handle(message data: [Any]) {
-    let msg = data[0] as! Message
+  func handle(message data: Any) {
+    let msg = data as! Message
 
     if self.shieldOptions.willIgnoreBots && msg.author?.isBot == true {
       return

--- a/Sources/Sword/Sword.swift
+++ b/Sources/Sword/Sword.swift
@@ -36,7 +36,7 @@ open class Sword: Eventable {
   public internal(set) var guilds = [String: Guild]()
 
   /// Event listeners
-  public var listeners = [Event: [([Any]) -> ()]]()
+  public var listeners = [Event: [(Any) -> ()]]()
 
   /// Optional options to apply to bot
   var options: SwordOptions

--- a/Sources/Sword/Utils/Enums.swift
+++ b/Sources/Sword/Utils/Enums.swift
@@ -68,7 +68,7 @@ public enum Event: String {
    ### Usage ###
    ```swift
    connection.on(.audioData) { data in
-     let audioData = data[0] as! Data
+     let audioData = data as! Data
    }
    ```
   */
@@ -80,7 +80,7 @@ public enum Event: String {
    ### Usage ###
    ```swift
    bot.on(.channelCreate) { data in
-     let channel = data[0] as! Channel
+     let channel = data as! Channel
    }
   */
   case channelCreate = "CHANNEL_CREATE"
@@ -91,7 +91,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.channelDelete) { data in
-       let channel = data[0] as! Channel
+       let channel = data as! Channel
      }
      ```
     */
@@ -103,7 +103,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.channelUpdate) { data in
-       let channel = data[0] as! Channel
+       let channel = data as! Channel
      }
      ```
     */
@@ -127,7 +127,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildAvailable) { data in
-       let guild = data[0] as! Guild
+       let guild = data as! Guild
      }
      ```
     */
@@ -139,8 +139,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildBanAdd) { data in
-       let guild = data[0] as! Guild
-       let user = data[1] as! User
+       let (guild, user) = data as! (Guild, User)
      }
      ```
     */
@@ -152,8 +151,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildBanRemove) { data in
-       let guild = data[0] as! Guild
-       let user = data[1] as! User
+       let (guild, user) = data as! (Guild, User)
      }
      ```
     */
@@ -165,7 +163,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildCreate) { data in
-       let guild = data[0] as! Guild
+       let guild = data as! Guild
      }
      ```
     */
@@ -177,7 +175,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildDelete) { data in
-       let guild = data[0] as! Guild
+       let guild = data as! Guild
      }
      ```
     */
@@ -189,8 +187,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildEmojisUpdate) { data in
-       let guild = data[0] as! Guild
-       let emojis = data[1] as! [Emoji]
+       let (guild, emojis) = data as! (Guild, [Emoji])
      }
      ```
     */
@@ -202,7 +199,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildIntegrationsUpdate) { data in
-       let guild = data[0] as! Guild
+       let guild = data as! Guild
      }
      ```
     */
@@ -214,8 +211,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildMemberAdd) { data in
-       let guild = data[0] as! Guild
-       let member = data[1] as! Member
+       let (guild, member) = data as! (Guild, Member)
      }
      ```
     */
@@ -227,8 +223,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildMemberRemove) { data in
-       let guild = data[0] as! Guild
-       let user = data[1] as! User
+       let (guild, user) = data as! (Guild, User)
      }
      ```
     */
@@ -240,7 +235,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildMemberUpdate) { data in
-       let member = data[0] as! Member
+       let member = data as! Member
      }
      ```
     */
@@ -255,8 +250,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildRoleCreate) { data in
-       let guild = data[0] as! Guild
-       let role = data[1] as! Role
+       let (guild, role) = data as! (Guild, Role)
      }
      ```
     */
@@ -268,8 +262,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildRoleDelete) { data in
-       let guild = data[0] as! Guild
-       let roleId = data[1] as! String
+       let (guild, roleID) = data as! (Guild, String)
      }
      ```
     */
@@ -281,8 +274,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildRoleUpdate) { data in
-       let guild = data[0] as! Guild
-       let role = data[1] as! Role
+       let (guild, role) = data as! (Guild, Role)
      }
      ```
     */
@@ -294,7 +286,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildUnavailable) { data in
-       let guild = data[0] as! UnavailableGuild
+       let guild = data as! UnavailableGuild
      }
      ```
     */
@@ -306,7 +298,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.guildUpdate) { data in
-       let guild = data[0] as! Guild
+       let guild = data as! Guild
      }
      ```
     */
@@ -318,7 +310,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.messageCreate) { data in
-       let msg = data[0] as! Message
+       let msg = data as! Message
      }
      ```
     */
@@ -330,11 +322,11 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.messageDelete) { data in
-      guard let msg = data[0] as? Message else {
-        //data has returned a string
+      guard let (msg, channel) = data as? (Message, Channel) else {
+        // data has returned an ID (string)
+        let (messageID, channel) = data as! (String, Channel)
         return
       }
-      let channel = data[1] as! Channel
      }
      ```
     */
@@ -346,8 +338,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.messageDeleteBulk) { data in
-       let messageIds = data[0] as! [String]
-       let channel = data[1] as! Channel
+       let (messageIDs, channel) = data as! ([String], Channel)
      }
      ```
     */
@@ -359,8 +350,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.messageUpdate) { data in
-       let msgId = data[0] as! String
-       let channelId = data[1] as! String
+       let (messageID, channelID) = data as! (String, String)
      }
      ```
     */
@@ -372,7 +362,7 @@ public enum Event: String {
    ### Usage ###
    ```swift
    bot.on(.payload) { data, in
-     let message = data[0] as! String
+     let message = data as! String
    }
    ```
   */
@@ -384,8 +374,7 @@ public enum Event: String {
    ### Usage ###
    ```swift
    bot.on(.presenceUpdate) { data in
-     let userId = data[0] as! String
-     let presence = data[1] as! Presence
+     let (userID, presence) = data as! (String, Presence)
    }
    ```
   */
@@ -397,7 +386,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.ready) { data in
-       let user = data[0] as! User
+       let user = data as! User
      }
      ```
     */
@@ -412,7 +401,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.shardReady) { data in
-       let shardId = data[0] as! Int
+       let shardID = data as! Int
      }
      ```
     */
@@ -424,9 +413,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.typingStart) { data in
-       let channel = data[0] as! Channel
-       let userId = data[1] as! String
-       let timestamp = data[2] as! Date
+       let (channel, userID, timestamp) = data as! (Channel, String, Date)
      }
      ```
     */
@@ -438,7 +425,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.userUpdate) { data in
-       let user = data[0] as! User
+       let user = data as! User
      }
      ```
     */
@@ -450,8 +437,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.voiceChannelJoin) { data in
-       let userId = data[0] as! String
-       let voiceState = data[1] as! VoiceState
+       let (userID, voiceState) = data as! (String, VoiceState)
      }
      ```
     */
@@ -463,7 +449,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.voiceChannelLeave) { data in
-       let userId = data[0] as! String
+       let userID = data as! String
      }
      ```
     */
@@ -475,7 +461,7 @@ public enum Event: String {
      ### Usage ###
      ```swift
      bot.on(.voiceStateUpdate) { data in
-       let userId = data[0] as! String
+       let userID = data as! String
      }
      ```
     */

--- a/Sources/Sword/Voice/VoiceConnection.swift
+++ b/Sources/Sword/Voice/VoiceConnection.swift
@@ -60,7 +60,7 @@ public class VoiceConnection: Eventable {
   public var isPlaying = false
 
   /// Event listeners
-  public var listeners = [Event: [([Any]) -> ()]]()
+  public var listeners = [Event: [(Any) -> ()]]()
 
   /// Port number for udp client
   var port: Int


### PR DESCRIPTION
This switches the event system from passing values as a varargs (`Any...`) to a single `Any` argument (which can be a tuple to pass multiple values).

Pros:
- Faster
- Simpler syntax (`let (guild, role) = data as! (Guild, Role)` vs `let guild = data[0] as! Guild; let role = data[1] as! Role`)

Cons:
- Breaking change, will require an update of all code that registers event handlers.  The compiler will catch the error, at least, since data[0] is no longer valid.