### PR TITLE
Update Discord Domain

### DIFF
--- a/Sources/Sword/Rest/Request.swift
+++ b/Sources/Sword/Rest/Request.swift
@@ -46,7 +46,7 @@ extension Sword {
       route += ".delete"
     }
 
-    var urlString = "https://discordapp.com/api/v7\(endpointInfo.url)"
+    var urlString = "https://discord.com/api/v7\(endpointInfo.url)"
 
     if let params = params {
       urlString += "?"

--- a/Sources/Sword/Sword.swift
+++ b/Sources/Sword/Sword.swift
@@ -265,7 +265,7 @@ open class Sword: Eventable {
   /**
    Creates a guild
 
-   - parameter options: Refer to [discord docs](https://discordapp.com/developers/docs/resources/guild#create-guild) for guild options
+   - parameter options: Refer to [discord docs](https://discord.com/developers/docs/resources/guild#create-guild) for guild options
   */
   public func createGuild(
     with options: [String: Any],
@@ -796,7 +796,7 @@ open class Sword: Eventable {
    - **avatar_url**: The url of the user the webhook will send
    - **tts**: Whether or not this message is tts
    - **file**: The url of the image to send
-   - **embeds**: Array of embed objects to send. Refer to [Embed structure](https://discordapp.com/developers/docs/resources/channel#embed-object)
+   - **embeds**: Array of embed objects to send. Refer to [Embed structure](https://discord.com/developers/docs/resources/channel#embed-object)
 
    - parameter webhookId: Webhook to execute
    - parameter webhookToken: Token for auth to execute
@@ -841,7 +841,7 @@ open class Sword: Eventable {
    #### Options Params ####
    
    - **user_id**: String of user to look for logs of
-   - **action_type**: Integer of Audit Log Event. Refer to [Audit Log Events](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
+   - **action_type**: Integer of Audit Log Event. Refer to [Audit Log Events](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
    - **before**: String of entry id to look before
    - **limit**: Integer of how many entries to return (default 50, minimum 1, maximum 100)
    
@@ -1718,7 +1718,7 @@ open class Sword: Eventable {
 
    #### Option Params ####
 
-   - **expire_behavior**: The behavior when an integration subscription lapses (see the [integration](https://discordapp.com/developers/docs/resources/guild#integration-object) object documentation)
+   - **expire_behavior**: The behavior when an integration subscription lapses (see the [integration](https://discord.com/developers/docs/resources/guild#integration-object) object documentation)
    - **expire_grace_period**: Period (in seconds) where the integration will ignore lapsed subscriptions
    - **enable_emoticons**: Whether emoticons should be synced for this integration (twitch only currently), true or false
 
@@ -1982,7 +1982,7 @@ open class Sword: Eventable {
    - **avatar_url**: The url of the user the webhook will send
    - **tts**: Whether or not this message is tts
    - **file**: The url of the image to send
-   - **embed**: The embed object to send. Refer to [Embed structure](https://discordapp.com/developers/docs/resources/channel#embed-object)
+   - **embed**: The embed object to send. Refer to [Embed structure](https://discord.com/developers/docs/resources/channel#embed-object)
 
    - parameter content: Dictionary containing info on message
    - parameter channelId: Channel to send message to

--- a/Sources/Sword/Types/Emoji.swift
+++ b/Sources/Sword/Types/Emoji.swift
@@ -84,7 +84,7 @@ public struct Emoji: Imageable {
     guard let id = self.id else {
       return nil
     }
-    
+    // as of 7/18/20, the CDN domain is still cdn.discordapp.com
     return URL(string: "https://cdn.discordapp.com/emojis/\(id).\(format)")
   }
 }

--- a/Sources/Sword/Types/Guild.swift
+++ b/Sources/Sword/Types/Guild.swift
@@ -375,7 +375,7 @@ public class Guild: Updatable, Imageable {
    #### Options Params ####
    
    - **user_id**: String of user to look for logs of
-   - **action_type**: Integer of Audit Log Event. Refer to [Audit Log Events](https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
+   - **action_type**: Integer of Audit Log Event. Refer to [Audit Log Events](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
    - **before**: String of entry id to look before
    - **limit**: Integer of how many entries to return (default 50, minimum 1, maximum 100)
    
@@ -475,7 +475,7 @@ public class Guild: Updatable, Imageable {
     guard let icon = self.icon else {
       return nil
     }
-    
+    // as of 7/18/20, the CDN domain is still cdn.discordapp.com
     return URL(string: "https://cdn.discordapp.com/icons/\(self.id)/\(icon).\(format)")
   }
   
@@ -562,7 +562,7 @@ public class Guild: Updatable, Imageable {
 
    #### Option Params ####
 
-   - **expire_behavior**: The behavior when an integration subscription lapses (see the [integration](https://discordapp.com/developers/docs/resources/guild#integration-object) object documentation)
+   - **expire_behavior**: The behavior when an integration subscription lapses (see the [integration](https://discord.com/developers/docs/resources/guild#integration-object) object documentation)
    - **expire_grace_period**: Period (in seconds) where the integration will ignore lapsed subscriptions
    - **enable_emoticons**: Whether emoticons should be synced for this integration (twitch only currently), true or false
 

--- a/Sources/Sword/Types/Message.swift
+++ b/Sources/Sword/Types/Message.swift
@@ -238,7 +238,7 @@ public struct Message {
    
    #### Message Options ####
    
-   Refer to Discord's documentation on the message body https://discordapp.com/developers/docs/resources/channel#create-message-json-params
+   Refer to Discord's documentation on the message body https://discord.com/developers/docs/resources/channel#create-message-json-params
    
    - parameter message: Dictionary containing information on the message
   */

--- a/Sources/Sword/Types/User.swift
+++ b/Sources/Sword/Types/User.swift
@@ -79,7 +79,7 @@ public struct User: Imageable {
         let discriminator = Int(discrim) else {
         return nil
       }
-      
+      // as of 7/18/20, the CDN domain is still cdn.discordapp.com
       return URL(string: "https://cdn.discordapp.com/embed/avatars/\(discriminator % 5).\(format)")
     }
     

--- a/Sources/Sword/Types/Webhook.swift
+++ b/Sources/Sword/Types/Webhook.swift
@@ -82,7 +82,7 @@ public struct Webhook {
    - **avatar_url**: The url of the user the webhook will send
    - **tts**: Whether or not this message is tts
    - **file**: The url of the image to send
-   - **embed**: The embed object to send. Refer to [Embed structure](https://discordapp.com/developers/docs/resources/channel#embed-object)
+   - **embed**: The embed object to send. Refer to [Embed structure](https://discord.com/developers/docs/resources/channel#embed-object)
 
    - parameter content: String or dictionary containing message content
   */

--- a/docs/Classes/Guild.html
+++ b/docs/Classes/Guild.html
@@ -1161,7 +1161,7 @@
 
 <ul>
 <li><strong>user_id</strong>: String of user to look for logs of</li>
-<li><strong>action_type</strong>: Integer of Audit Log Event. Refer to <a href="https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events">Audit Log Events</a></li>
+<li><strong>action_type</strong>: Integer of Audit Log Event. Refer to <a href="https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events">Audit Log Events</a></li>
 <li><strong>before</strong>: String of entry id to look before</li>
 <li><p><strong>limit</strong>: Integer of how many entries to return (default 50, minimum 1, maximum 100)</p></li>
 </ul>
@@ -1615,7 +1615,7 @@
 <h4 id='option-params' class='heading'>Option Params</h4>
 
 <ul>
-<li><strong>expire_behavior</strong>: The behavior when an integration subscription lapses (see the <a href="https://discordapp.com/developers/docs/resources/guild#integration-object">integration</a> object documentation)</li>
+<li><strong>expire_behavior</strong>: The behavior when an integration subscription lapses (see the <a href="https://discord.com/developers/docs/resources/guild#integration-object">integration</a> object documentation)</li>
 <li><strong>expire_grace_period</strong>: Period (in seconds) where the integration will ignore lapsed subscriptions</li>
 <li><p><strong>enable_emoticons</strong>: Whether emoticons should be synced for this integration (twitch only currently), true or false</p></li>
 </ul>

--- a/docs/Classes/Sword.html
+++ b/docs/Classes/Sword.html
@@ -1495,7 +1495,7 @@
 <li><strong>avatar_url</strong>: The url of the user the webhook will send</li>
 <li><strong>tts</strong>: Whether or not this message is tts</li>
 <li><strong>file</strong>: The url of the image to send</li>
-<li><p><strong>embeds</strong>: Array of embed objects to send. Refer to <a href="https://discordapp.com/developers/docs/resources/channel#embed-object">Embed structure</a></p></li>
+<li><p><strong>embeds</strong>: Array of embed objects to send. Refer to <a href="https://discord.com/developers/docs/resources/channel#embed-object">Embed structure</a></p></li>
 </ul>
 
                       </div>
@@ -1533,7 +1533,7 @@
 
 <ul>
 <li><strong>user_id</strong>: String of user to look for logs of</li>
-<li><strong>action_type</strong>: Integer of Audit Log Event. Refer to <a href="https://discordapp.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events">Audit Log Events</a></li>
+<li><strong>action_type</strong>: Integer of Audit Log Event. Refer to <a href="https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events">Audit Log Events</a></li>
 <li><strong>before</strong>: String of entry id to look before</li>
 <li><p><strong>limit</strong>: Integer of how many entries to return (default 50, minimum 1, maximum 100)</p></li>
 </ul>
@@ -2795,7 +2795,7 @@
 <h4 id='option-params' class='heading'>Option Params</h4>
 
 <ul>
-<li><strong>expire_behavior</strong>: The behavior when an integration subscription lapses (see the <a href="https://discordapp.com/developers/docs/resources/guild#integration-object">integration</a> object documentation)</li>
+<li><strong>expire_behavior</strong>: The behavior when an integration subscription lapses (see the <a href="https://discord.com/developers/docs/resources/guild#integration-object">integration</a> object documentation)</li>
 <li><strong>expire_grace_period</strong>: Period (in seconds) where the integration will ignore lapsed subscriptions</li>
 <li><p><strong>enable_emoticons</strong>: Whether emoticons should be synced for this integration (twitch only currently), true or false</p></li>
 </ul>
@@ -3154,7 +3154,7 @@
 <li><strong>avatar_url</strong>: The url of the user the webhook will send</li>
 <li><strong>tts</strong>: Whether or not this message is tts</li>
 <li><strong>file</strong>: The url of the image to send</li>
-<li><p><strong>embed</strong>: The embed object to send. Refer to <a href="https://discordapp.com/developers/docs/resources/channel#embed-object">Embed structure</a></p></li>
+<li><p><strong>embed</strong>: The embed object to send. Refer to <a href="https://discord.com/developers/docs/resources/channel#embed-object">Embed structure</a></p></li>
 </ul>
 
                       </div>

--- a/docs/Structs/Message.html
+++ b/docs/Structs/Message.html
@@ -991,7 +991,7 @@
                         <p>Replies to a channel</p>
 <h4 id='message-options' class='heading'>Message Options</h4>
 
-<p>Refer to Discord&rsquo;s documentation on the message body <a href="https://discordapp.com/developers/docs/resources/channel#create-message-json-params">https://discordapp.com/developers/docs/resources/channel#create-message-json-params</a></p>
+<p>Refer to Discord&rsquo;s documentation on the message body <a href="https://discord.com/developers/docs/resources/channel#create-message-json-params">https://discord.com/developers/docs/resources/channel#create-message-json-params</a></p>
 
                       </div>
                       <div class="declaration">

--- a/docs/Structs/Webhook.html
+++ b/docs/Structs/Webhook.html
@@ -522,7 +522,7 @@
 <li><strong>avatar_url</strong>: The url of the user the webhook will send</li>
 <li><strong>tts</strong>: Whether or not this message is tts</li>
 <li><strong>file</strong>: The url of the image to send</li>
-<li><p><strong>embed</strong>: The embed object to send. Refer to <a href="https://discordapp.com/developers/docs/resources/channel#embed-object">Embed structure</a></p></li>
+<li><p><strong>embed</strong>: The embed object to send. Refer to <a href="https://discord.com/developers/docs/resources/channel#embed-object">Embed structure</a></p></li>
 </ul>
 
                       </div>


### PR DESCRIPTION
According to an email from Discord:  
Discord has officially moved to discord.com. On November 7, 2020, Discord will be dropping support for the discordapp.com domain in favor of discord.com. Their CDN domain will not be migrated and it will remain cdn.discordapp.com for the foreseeable future.